### PR TITLE
fix: documentation not displayed properly

### DIFF
--- a/docs/_data/mesheryctlcommands/cmds.yml
+++ b/docs/_data/mesheryctlcommands/cmds.yml
@@ -910,8 +910,8 @@ model:
           name: --template, -t
           description: Specify the path to the template JSON file (only required for URLs).
         register:
-        name: --register, -r
-        description: Skip model registration (default is true).    
+          name: --register, -r
+          description: Skip model registration (default is true).    
     view:
       name: view
       description: View details of a specific model

--- a/docs/pages/reference/mesheryctl-commands.md
+++ b/docs/pages/reference/mesheryctl-commands.md
@@ -747,8 +747,14 @@ Installation, troubleshooting and debugging of Meshery and its adapters
     <th>Function</th>
   </tr>
   {% assign command12 = site.data.mesheryctlcommands.cmds.model %}
+  {% assign subcommand12_flag_count = 0 %}
+    {% for subcommand12_hash in command12.subcommands %}
+      {% assign subcommand = subcommand12_hash[1] %}
+      {% assign subcommand12_flag_count = subcommand12_flag_count | plus: subcommand.flags.size %}
+    {% endfor %}
+    {% assign total_rowspan = command12.subcommands.size | plus: subcommand12_flag_count | plus: command12.flags.size | plus: 1 %}
     <tr>
-      <td rowspan=11><a href="{{ site.baseurl }}/reference/mesheryctl/{{ command12.name }}">{{ command12.name }}</a></td>
+      <td rowspan={{ total_rowspan }}><a href="{{ site.baseurl }}/reference/mesheryctl/{{ command12.name }}">{{ command12.name }}</a></td>
       <td></td>
       <td></td>
       <td>{{ command12.description }}</td>


### PR DESCRIPTION
- **add number list in the notification**
- **DOC: change '3)' to '2)' in relationships.md**
- **DOC: change '3)' to '2)' in relationships.md**
- **[Docs] Update _catalog collection**
- **latest discussion data files added**
- **[Docs] Update _catalog collection**
- **[Docs] Generated documentation for Integration**
- **Fixed the duplicate import subcommand bug with generate subcommand and refactor docs**
- **doc: fix yaml indentation issue and make jekyll template improvement**
